### PR TITLE
Fix loot all button for plunder chests

### DIFF
--- a/src/main/java/dev/jb0s/blockgameenhanced/mixin/gui/screen/MixinGenericContainerScreen.java
+++ b/src/main/java/dev/jb0s/blockgameenhanced/mixin/gui/screen/MixinGenericContainerScreen.java
@@ -43,7 +43,7 @@ public class MixinGenericContainerScreen extends HandledScreen<GenericContainerS
 
         // If this is not a regular chest we're interacting with, don't add the loot all button
         String titleStr = title.getString();
-        boolean isValidContainer = titleStr.endsWith("Chest") || titleStr.endsWith("Shulker Box") || titleStr.endsWith("Barrel");
+        boolean isValidContainer = titleStr.endsWith("Plunder") || titleStr.endsWith("Chest") || titleStr.endsWith("Shulker Box") || titleStr.endsWith("Barrel");
         if(!titleStr.isEmpty() && !isValidContainer) {
             return;
         }


### PR DESCRIPTION
Added `Plunder` to the checked container names to bring back the button