### PR TITLE
Fix Jukebox in Origin when joining

### DIFF
--- a/src/main/java/dev/jb0s/blockgameenhanced/gamefeature/jukebox/JukeboxGameFeature.java
+++ b/src/main/java/dev/jb0s/blockgameenhanced/gamefeature/jukebox/JukeboxGameFeature.java
@@ -227,6 +227,10 @@ public class JukeboxGameFeature extends GameFeature {
             if(playerEntity == null) {
                 return;
             }
+            if(mus.getSoundId(getMusicSoundIndex()) == null) {
+                BlockgameEnhanced.LOGGER.warn("Couldn't play: " + music + " (" + getMusicSoundIndex() + ")");
+                return;
+            }
 
             currentMusic = mus;
             desiredMusic = mus;


### PR DESCRIPTION
This is not a full fix, but fixes the crash. Looks like it tries to play a sound without a time of day suffix when joining, but that doesn't exist.

It plays fine when warping to Origin though, so needs more debugging.