### PR TITLE
Fix offset GUI elements when an MMOItem is on screen

### DIFF
--- a/src/main/java/dev/jb0s/blockgameenhanced/mixin/gui/MixinDrawContext.java
+++ b/src/main/java/dev/jb0s/blockgameenhanced/mixin/gui/MixinDrawContext.java
@@ -19,6 +19,7 @@ public class MixinDrawContext {
         ActionResult result = ItemRendererDrawEvent.EVENT.invoker().drawItem(thisContext, renderer, stack, x, y, countLabel);
 
         if(result != ActionResult.PASS) {
+            thisContext.getMatrices().pop();
             ci.cancel();
         }
     }


### PR DESCRIPTION
This way changes the least amount of code in other places, but it could be done in the event invoker factory to avoid having to pop manually.