### PR TITLE
Add Server Resource Pack Config

### DIFF
--- a/src/main/java/dev/jb0s/blockgameenhanced/config/modules/ModConfig.java
+++ b/src/main/java/dev/jb0s/blockgameenhanced/config/modules/ModConfig.java
@@ -26,4 +26,8 @@ public class ModConfig extends PartitioningSerializer.GlobalData {
     @Getter
     @ConfigEntry.Gui.CollapsibleObject(startExpanded = true)
     ChatChannelsConfig chatChannelsConfig = new ChatChannelsConfig();
+
+    @Getter
+    @ConfigEntry.Gui.CollapsibleObject(startExpanded = true)
+    ServerConfig serverConfig = new ServerConfig();
 }

--- a/src/main/java/dev/jb0s/blockgameenhanced/config/modules/ServerConfig.java
+++ b/src/main/java/dev/jb0s/blockgameenhanced/config/modules/ServerConfig.java
@@ -1,0 +1,23 @@
+package dev.jb0s.blockgameenhanced.config.modules;
+
+import dev.jb0s.blockgameenhanced.BlockgameEnhanced;
+import me.shedaniel.autoconfig.ConfigData;
+import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
+import net.minecraft.client.network.ServerInfo;
+
+@Config(name = "server")
+public class ServerConfig implements ConfigData {
+  @ConfigEntry.Gui.Tooltip(count = 2)
+  public boolean enableResourcePackPrompt;
+
+  public ServerConfig() {
+    enableResourcePackPrompt = true;
+  }
+
+  public static void updateServerInfo(ServerInfo serverInfo) {
+    serverInfo.setResourcePackPolicy(BlockgameEnhanced.getConfig().getServerConfig().enableResourcePackPrompt
+        ? ServerInfo.ResourcePackPolicy.PROMPT
+        : ServerInfo.ResourcePackPolicy.ENABLED);
+  }
+}

--- a/src/main/java/dev/jb0s/blockgameenhanced/gui/screen/TitleScreen.java
+++ b/src/main/java/dev/jb0s/blockgameenhanced/gui/screen/TitleScreen.java
@@ -3,6 +3,7 @@ package dev.jb0s.blockgameenhanced.gui.screen;
 import com.mojang.blaze3d.systems.RenderSystem;
 import dev.jb0s.blockgameenhanced.BlockgameEnhanced;
 import dev.jb0s.blockgameenhanced.BlockgameEnhancedClient;
+import dev.jb0s.blockgameenhanced.config.modules.ServerConfig;
 import dev.jb0s.blockgameenhanced.eggs.ThorScreen;
 import dev.jb0s.blockgameenhanced.config.ConfigManager;
 import lombok.SneakyThrows;
@@ -76,6 +77,7 @@ public class TitleScreen extends Screen {
         // Initialize server pinger & server info
         pinger = new MultiplayerServerListPinger();
         serverInfo = new ServerInfo("Blockgame", "mc.blockgame.info", ServerInfo.ServerType.OTHER);
+        ServerConfig.updateServerInfo(serverInfo);
 
         // Start pinging server
         Thread pingThread = new Thread(() -> {
@@ -254,9 +256,12 @@ public class TitleScreen extends Screen {
                 .dimensions(i + 1, l + 24, 89, 20)
                 .build());
 
+        ServerInfo sInfo = new ServerInfo("BlockGame", "mc.blockgame.info", ServerInfo.ServerType.OTHER);
+        ServerConfig.updateServerInfo(sInfo);
+
         // Add Play Button
         addDrawableChild(ButtonWidget.builder(BUTTON_PLAY,
-                (button) -> ConnectScreen.connect(this, this.client, ServerAddress.parse("mc.blockgame.info"), new ServerInfo("BlockGame", "mc.blockgame.info", ServerInfo.ServerType.OTHER), true))
+                (button) -> ConnectScreen.connect(this, this.client, ServerAddress.parse("mc.blockgame.info"), sInfo, true))
                 .dimensions(i - 90, l, 180, 20)
                 .build());
 

--- a/src/main/resources/assets/blockgame/lang/en_us.json
+++ b/src/main/resources/assets/blockgame/lang/en_us.json
@@ -107,6 +107,10 @@
 	"text.autoconfig.blockgameenhanced.option.chatChannelsConfig.closeChatAfterMessage.@Tooltip": "Close the chat box after sending a message",
 	"text.autoconfig.blockgameenhanced.option.chatChannelsConfig.compactButton": "Compact channel button",
 	"text.autoconfig.blockgameenhanced.option.chatChannelsConfig.compactButton.@Tooltip": "Make the chat button a square with a single letter",
+	"text.autoconfig.blockgameenhanced.option.serverConfig": "Server Config",
+	"text.autoconfig.blockgameenhanced.option.serverConfig.enableResourcePackPrompt": "Enable server resource pack prompt",
+	"text.autoconfig.blockgameenhanced.option.serverConfig.enableResourcePackPrompt.@Tooltip[0]": "Whether to be prompted to install the required resource pack when connecting to the server.",
+	"text.autoconfig.blockgameenhanced.option.serverConfig.enableResourcePackPrompt.@Tooltip[1]": "NOTE: Disabling this means you accept the custom resource pack",
 
 	"comment.9": "~~ Update Popup ~~",
 	"menu.blockgame.update.header": "Update available",


### PR DESCRIPTION
Adds an option to disable the server resource pack prompt when logging into the server. Probably the silliest thing to add, but the default MC multiplayer server config has this option. So for continuity sake, here yah go.

![image](https://github.com/jb0s/blockgame-enhanced/assets/6426155/a029541e-8139-42cc-8399-b2dde642471a)

By default this option is enabled to keep consistency with how the flow works today. Those users that are bothered by it can then disable the option in the settings.