### PR TITLE
Jukebox Config

### DIFF
--- a/src/main/java/dev/jb0s/blockgameenhanced/BlockgameEnhancedClient.java
+++ b/src/main/java/dev/jb0s/blockgameenhanced/BlockgameEnhancedClient.java
@@ -1,5 +1,6 @@
 package dev.jb0s.blockgameenhanced;
 
+import dev.jb0s.blockgameenhanced.config.ConfigManager;
 import dev.jb0s.blockgameenhanced.gamefeature.GameFeature;
 import dev.jb0s.blockgameenhanced.gamefeature.bettergui.BetterGUIGameFeature;
 import dev.jb0s.blockgameenhanced.gamefeature.dayphase.DayPhaseGameFeature;
@@ -16,7 +17,6 @@ import dev.jb0s.blockgameenhanced.gamefeature.titlescreen.TitleScreenGameFeature
 import dev.jb0s.blockgameenhanced.gamefeature.updateprompter.UpdatePrompterGameFeature;
 import dev.jb0s.blockgameenhanced.gamefeature.zone.ZoneGameFeature;
 import dev.jb0s.blockgameenhanced.gamefeature.zoneboss.ZoneBossGameFeature;
-import dev.jb0s.blockgameenhanced.config.ConfigManager;
 import dev.jb0s.blockgameenhanced.update.GitHubRelease;
 import dev.jb0s.blockgameenhanced.update.UpdateManager;
 import lombok.Getter;

--- a/src/main/java/dev/jb0s/blockgameenhanced/config/modules/JukeboxConfig.java
+++ b/src/main/java/dev/jb0s/blockgameenhanced/config/modules/JukeboxConfig.java
@@ -1,0 +1,19 @@
+package dev.jb0s.blockgameenhanced.config.modules;
+
+import me.shedaniel.autoconfig.ConfigData;
+import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
+
+@Config(name = "jukebox")
+public class JukeboxConfig implements ConfigData {
+  @ConfigEntry.Gui.Tooltip
+  public boolean enableJukebox;
+
+  @ConfigEntry.Gui.Tooltip
+  public boolean vanillaInWilderness;
+
+  public JukeboxConfig() {
+    enableJukebox = true;
+    vanillaInWilderness = true;
+  }
+}

--- a/src/main/java/dev/jb0s/blockgameenhanced/config/modules/ModConfig.java
+++ b/src/main/java/dev/jb0s/blockgameenhanced/config/modules/ModConfig.java
@@ -17,6 +17,10 @@ public class ModConfig extends PartitioningSerializer.GlobalData {
 
     @Getter
     @ConfigEntry.Gui.CollapsibleObject(startExpanded = true)
+    JukeboxConfig jukeboxConfig = new JukeboxConfig();
+
+    @Getter
+    @ConfigEntry.Gui.CollapsibleObject(startExpanded = true)
     PrivacyConfig privacyConfig = new PrivacyConfig();
 
     @Getter

--- a/src/main/java/dev/jb0s/blockgameenhanced/event/sound/MusicTypeAccessedEvent.java
+++ b/src/main/java/dev/jb0s/blockgameenhanced/event/sound/MusicTypeAccessedEvent.java
@@ -1,0 +1,18 @@
+package dev.jb0s.blockgameenhanced.event.sound;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.sound.MusicSound;
+
+public interface MusicTypeAccessedEvent {
+    Event<MusicTypeAccessedEvent> EVENT = EventFactory.createArrayBacked(MusicTypeAccessedEvent.class, (listeners) -> () -> {
+        for (MusicTypeAccessedEvent listener : listeners) {
+            var sound = listener.musicTypeAccessed();
+            if (sound != null) return sound;
+        }
+
+        return null;
+    });
+
+    MusicSound musicTypeAccessed();
+}

--- a/src/main/java/dev/jb0s/blockgameenhanced/gamefeature/jukebox/JukeboxGameFeature.java
+++ b/src/main/java/dev/jb0s/blockgameenhanced/gamefeature/jukebox/JukeboxGameFeature.java
@@ -3,12 +3,14 @@ package dev.jb0s.blockgameenhanced.gamefeature.jukebox;
 import com.google.gson.Gson;
 import dev.jb0s.blockgameenhanced.BlockgameEnhanced;
 import dev.jb0s.blockgameenhanced.BlockgameEnhancedClient;
+import dev.jb0s.blockgameenhanced.config.modules.JukeboxConfig;
 import dev.jb0s.blockgameenhanced.event.adventurezone.EnteredWildernessEvent;
 import dev.jb0s.blockgameenhanced.event.adventurezone.PlayerEnteredZoneEvent;
 import dev.jb0s.blockgameenhanced.event.bossbattle.BossBattleCommencedEvent;
 import dev.jb0s.blockgameenhanced.event.bossbattle.BossBattleEndedEvent;
 import dev.jb0s.blockgameenhanced.event.dayphase.DayPhaseChangedEvent;
 import dev.jb0s.blockgameenhanced.event.entity.player.PlayerRespawnedEvent;
+import dev.jb0s.blockgameenhanced.event.sound.MusicTypeAccessedEvent;
 import dev.jb0s.blockgameenhanced.gamefeature.GameFeature;
 import dev.jb0s.blockgameenhanced.gamefeature.dayphase.DayPhase;
 import dev.jb0s.blockgameenhanced.gamefeature.jukebox.json.JsonMusic;
@@ -25,10 +27,15 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.sound.SoundManager;
 import net.minecraft.client.toast.SystemToast;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.sound.MusicSound;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.World;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -36,6 +43,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class JukeboxGameFeature extends GameFeature {
+    private static final MusicSound MUSIC_SILENCE = new MusicSound(RegistryEntry.of(SoundEvent.of(new Identifier("blockgame", "silence"))), 999999, 999999, false);
     private static final String DATA_RESOURCE_PATH = "assets/blockgame/data/config/music.json";
 
     private SoundManager soundManager;
@@ -72,6 +80,17 @@ public class JukeboxGameFeature extends GameFeature {
     public void init(MinecraftClient minecraftClient, BlockgameEnhancedClient blockgameClient) {
         super.init(minecraftClient, blockgameClient);
         loadData();
+
+        MusicTypeAccessedEvent.EVENT.register(() -> {
+            World world = MinecraftClient.getInstance().world;
+            JukeboxConfig config = BlockgameEnhanced.getConfig().getJukeboxConfig();
+
+            if (world == null || !config.enableJukebox || (config.vanillaInWilderness && currentZone == null)) {
+                return null;
+            }
+
+            return MUSIC_SILENCE;
+        });
 
         // Play zone music when player enters zone.
         PlayerEnteredZoneEvent.EVENT.register((client, playerEntity, zone) -> {
@@ -191,6 +210,10 @@ public class JukeboxGameFeature extends GameFeature {
                 }
             }
         }
+
+        if (!isPlaying() && !isMuted()) {
+            MinecraftClient.getInstance().getMusicTracker().tick();
+        }
     }
 
     private void loadData() {
@@ -237,6 +260,8 @@ public class JukeboxGameFeature extends GameFeature {
             currentMusic = mus;
             desiredMusic = mus;
 
+            this.getMinecraftClient().getMusicTracker().stop();
+
             BlockgameEnhanced.LOGGER.info("Now playing: " + music + " (" + getMusicSoundIndex() + ")");
             soundInstance = new MusicSoundInstance(SoundEvent.of(mus.getSoundId(getMusicSoundIndex())), SoundCategory.MUSIC, 1f, 1f, playerEntity);
             soundManager.play(soundInstance, delay);
@@ -267,6 +292,9 @@ public class JukeboxGameFeature extends GameFeature {
             currentMusic = null;
             playing = false;
             fading = false;
+
+            // This allows the wilderness music to start sooner if the player has this enabled.
+            this.getMinecraftClient().getMusicTracker().timeUntilNextSong = 2500;
         }
         else {
             fading = true;
@@ -335,6 +363,11 @@ public class JukeboxGameFeature extends GameFeature {
         }
 
         return currentDayPhase.getId();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return BlockgameEnhanced.getConfig().getJukeboxConfig().enableJukebox;
     }
 
     @Override

--- a/src/main/java/dev/jb0s/blockgameenhanced/mixin/client/MixinMinecraftClient.java
+++ b/src/main/java/dev/jb0s/blockgameenhanced/mixin/client/MixinMinecraftClient.java
@@ -3,17 +3,14 @@ package dev.jb0s.blockgameenhanced.mixin.client;
 import dev.jb0s.blockgameenhanced.event.client.ClientDisconnectionEvents;
 import dev.jb0s.blockgameenhanced.event.client.ClientLifetimeEvents;
 import dev.jb0s.blockgameenhanced.event.client.ClientScreenChanged;
+import dev.jb0s.blockgameenhanced.event.sound.MusicTypeAccessedEvent;
 import dev.jb0s.blockgameenhanced.event.world.WorldUpdatedEvent;
 import lombok.SneakyThrows;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.RunArgs;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.world.ClientWorld;
-import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.sound.MusicSound;
-import net.minecraft.sound.SoundEvent;
-import net.minecraft.util.Identifier;
-import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -22,17 +19,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(MinecraftClient.class)
 public abstract class MixinMinecraftClient {
-    private static final MusicSound MUSIC_SILENCE = new MusicSound(RegistryEntry.of(SoundEvent.of(new Identifier("blockgame", "silence"))), 999999, 999999, false);
-
-    /**
-     * todo move this to JukeboxGameFeature
-     * @param cir
-     */
     @Inject(method = "getMusicType", at = @At("RETURN"), cancellable = true)
     public void getMusicType(CallbackInfoReturnable<MusicSound> cir) {
-        World world = MinecraftClient.getInstance().world;
-        if(world != null) {
-            cir.setReturnValue(MUSIC_SILENCE);
+        MusicSound musicSound = MusicTypeAccessedEvent.EVENT.invoker().musicTypeAccessed();
+        if (musicSound != null) {
+            cir.setReturnValue(musicSound);
         }
     }
 

--- a/src/main/resources/assets/blockgame/lang/en_us.json
+++ b/src/main/resources/assets/blockgame/lang/en_us.json
@@ -112,6 +112,11 @@
 	"text.autoconfig.blockgameenhanced.option.serverConfig.enableResourcePackPrompt": "Enable server resource pack prompt",
 	"text.autoconfig.blockgameenhanced.option.serverConfig.enableResourcePackPrompt.@Tooltip[0]": "Whether to be prompted to install the required resource pack when connecting to the server.",
 	"text.autoconfig.blockgameenhanced.option.serverConfig.enableResourcePackPrompt.@Tooltip[1]": "NOTE: Disabling this means you accept the custom resource pack",
+	"text.autoconfig.blockgameenhanced.option.jukeboxConfig": "Music / Sounds",
+	"text.autoconfig.blockgameenhanced.option.jukeboxConfig.enableJukebox": "Enable custom Blockgame music",
+	"text.autoconfig.blockgameenhanced.option.jukeboxConfig.enableJukebox.@Tooltip": "Enable custom music tracks to play in-game when in certain areas.",
+	"text.autoconfig.blockgameenhanced.option.jukeboxConfig.vanillaInWilderness": "Play vanilla music in wilderness",
+	"text.autoconfig.blockgameenhanced.option.jukeboxConfig.vanillaInWilderness.@Tooltip": "Whether or not to play vanilla music in the wilderness.",
 
 	"comment.9": "~~ Update Popup ~~",
 	"menu.blockgame.update.header": "Update available",

--- a/src/main/resources/blockgameenhanced.accesswidener
+++ b/src/main/resources/blockgameenhanced.accesswidener
@@ -43,3 +43,5 @@ accessible field net/minecraft/client/gui/screen/Screen selectables Ljava/util/L
 
 # net.minecraft.client.gui.screen.SplashOverlay
 accessible field net/minecraft/client/gui/screen/SplashOverlay reloadCompleteTime J
+
+accessible field net/minecraft/client/sound/MusicTracker timeUntilNextSong I


### PR DESCRIPTION
### Main Updates
- Added configuration to allow users to turn off the jukebox music
- Added an option to play Vanilla music in the wilderness (where right now there is just silence).

![image](https://github.com/jb0s/blockgame-enhanced/assets/6426155/6af09037-1b85-4300-a34c-6847f936fd88)

### Dev Updates
- Moved logic for `getMusicType()` mixin into the Jukebox game feature using an event