### PR TITLE
Added a refresh button to the Title Screen

### DIFF
--- a/src/main/java/dev/jb0s/blockgameenhanced/gui/screen/TitleScreen.java
+++ b/src/main/java/dev/jb0s/blockgameenhanced/gui/screen/TitleScreen.java
@@ -32,6 +32,7 @@ public class TitleScreen extends Screen {
     private static final Identifier BLOCKGAME_LOGO_TEXTURE = new Identifier("blockgame", "textures/gui/title/blockgame.png");
 
     private static final MutableText BUTTON_PLAY = Text.translatable("menu.blockgame.title.play");
+    private static final MutableText BUTTON_REFRESH = Text.translatable("menu.blockgame.title.refresh");
     private static final MutableText BUTTON_WEBSITE = Text.translatable("menu.blockgame.title.website");
     private static final MutableText BUTTON_WIKI = Text.translatable("menu.blockgame.title.wiki");
     private static final MutableText WATERMARK = Text.translatable("menu.blockgame.title.watermark", FabricLoader.getInstance().getModContainer("blockgameenhanced").get().getMetadata().getVersion().getFriendlyString());
@@ -263,6 +264,12 @@ public class TitleScreen extends Screen {
         addDrawableChild(ButtonWidget.builder(BUTTON_PLAY,
                 (button) -> ConnectScreen.connect(this, this.client, ServerAddress.parse("mc.blockgame.info"), sInfo, true))
                 .dimensions(i - 90, l, 180, 20)
+                .build());
+
+        // Add Refresh Button
+        addDrawableChild(ButtonWidget.builder(BUTTON_REFRESH,
+                (button) -> this.client.setScreen(new TitleScreen()))
+                .dimensions(i + 90, l, 20, 20)
                 .build());
 
         // If ModMenu mod is present, add the "Mods" button to the screen

--- a/src/main/resources/assets/blockgame/lang/en_us.json
+++ b/src/main/resources/assets/blockgame/lang/en_us.json
@@ -16,6 +16,7 @@
 
 	"comment.2": "~~ Title Screen ~~",
 	"menu.blockgame.title.play": "Play",
+	"menu.blockgame.title.refresh": "⭮",
 	"menu.blockgame.title.website": "Website",
 	"menu.blockgame.title.wiki": "Wiki",
 	"menu.blockgame.title.watermark": "Blockgame Enhanced v%s by notIrma",


### PR DESCRIPTION
Added a refresh button to the Title Screen, similar to what is present in the vanilla Multiplayer.

This is mostly a nice thing to have, as sometimes the server times out and this seems like a better way to check if it is back on instead of trying to log in constantly.

![title_btn](https://github.com/user-attachments/assets/e0b55e52-e276-4f74-b5ac-f4dfc8ddf96a)
