### PR TITLE
Quick fix for getting locked out of chests

### DIFF
--- a/src/main/java/dev/jb0s/blockgameenhanced/mixin/interaction/MixinClientPlayerInteractionManager.java
+++ b/src/main/java/dev/jb0s/blockgameenhanced/mixin/interaction/MixinClientPlayerInteractionManager.java
@@ -1,0 +1,30 @@
+package dev.jb0s.blockgameenhanced.mixin.interaction;
+
+import net.minecraft.block.Blocks;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ClientPlayerInteractionManager.class)
+public class MixinClientPlayerInteractionManager {
+    @Shadow @Final
+    private MinecraftClient client;
+
+    @Inject(method = "interactBlock", at = @At("HEAD"), cancellable = true)
+    private void cancelSuspiciousInteraction(ClientPlayerEntity player, Hand hand, BlockHitResult hitResult, CallbackInfoReturnable<ActionResult> cir) {
+        if (client.world.getBlockState(hitResult.getBlockPos()).isOf(Blocks.SUSPICIOUS_GRAVEL) ||
+            client.world.getBlockState(hitResult.getBlockPos()).isOf(Blocks.SUSPICIOUS_SAND))
+        {
+            cir.setReturnValue(ActionResult.FAIL);
+        }
+    }
+}

--- a/src/main/resources/BlockgameEnhanced.mixins.json
+++ b/src/main/resources/BlockgameEnhanced.mixins.json
@@ -20,6 +20,7 @@
     "gui.screen.MixinGameMenuScreen",
     "gui.screen.MixinGenericContainerScreen",
     "gui.screen.MixinScreen",
+    "interaction.MixinClientPlayerInteractionManager",
     "items.MixinItem",
     "items.MixinItemStack",
     "network.MixinClientPlayNetworkHandler",


### PR DESCRIPTION
This fix removes the ability of the player to interact with "Suspicious" blocks as doing so would cause chests to not be interactable anymore.

An example of this behaviour can be seen here:
https://github.com/user-attachments/assets/cb2bac38-4b1b-4ba6-906b-5042f5484d22
